### PR TITLE
fix fishing barge hopper deletion bug

### DIFF
--- a/src/main/java/dev/murad/shipping/entity/custom/barge/FishingBargeEntity.java
+++ b/src/main/java/dev/murad/shipping/entity/custom/barge/FishingBargeEntity.java
@@ -262,7 +262,7 @@ public class FishingBargeEntity extends AbstractBargeEntity implements IInventor
 
     @Override
     public void setItem(int p_70299_1_, ItemStack p_70299_2_) {
-
+        itemHandler.setStackInSlot(p_70299_1_, p_70299_2_);
     }
 
     @Override


### PR DESCRIPTION
Turns out hoppers remove items and put them back instead of checking if it's movable. They won't insert into fishing barge though (as desired) because canPlaceItem is false.