### PR TITLE
Separate vessel spring entity from generic linking logic (Linking refactor 2)

### DIFF
--- a/src/main/java/dev/murad/shipping/entity/custom/VesselEntity.java
+++ b/src/main/java/dev/murad/shipping/entity/custom/VesselEntity.java
@@ -1,8 +1,8 @@
 package dev.murad.shipping.entity.custom;
 
-import com.mojang.datafixers.util.Pair;
 import dev.murad.shipping.ShippingConfig;
 import dev.murad.shipping.util.LinkableEntity;
+import dev.murad.shipping.util.SpringableEntity;
 import dev.murad.shipping.util.Train;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -47,7 +47,8 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Optional;
 
-public abstract class VesselEntity extends WaterAnimal implements LinkableEntity {
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+public abstract class VesselEntity extends WaterAnimal implements SpringableEntity {
     protected VesselEntity(EntityType<? extends WaterAnimal> type, Level world) {
         super(type, world);
         stuckCounter = 0;
@@ -64,8 +65,10 @@ public abstract class VesselEntity extends WaterAnimal implements LinkableEntity
     private Boat.Status oldStatus;
     private double lastYd;
 
-    protected Optional<Pair<LinkableEntity, SpringEntity>> dominated = Optional.empty();
-    protected Optional<Pair<LinkableEntity, SpringEntity>> dominant = Optional.empty();
+    protected Optional<SpringableEntity> dominated = Optional.empty();
+    protected Optional<SpringableEntity> dominant = Optional.empty();
+    protected Optional<SpringEntity> dominantS = Optional.empty();
+    protected Optional<SpringEntity> dominatedS = Optional.empty();
     protected Train train;
 
     @Override
@@ -147,13 +150,23 @@ public abstract class VesselEntity extends WaterAnimal implements LinkableEntity
     public abstract Item getDropItem();
 
     @Override
-    public Optional<Pair<LinkableEntity, SpringEntity>> getDominated() {
-        return this.dominated;
+    public Optional<LinkableEntity> getDominated() {
+        return this.dominated.map(s -> s); // Java...
     }
 
     @Override
-    public Optional<Pair<LinkableEntity, SpringEntity>> getDominant() {
-        return this.dominant;
+    public Optional<SpringEntity> getDominatedSpring() {
+        return this.dominatedS; // Java...
+    }
+
+    @Override
+    public Optional<LinkableEntity> getDominant() {
+        return this.dominant.map(s -> s); // Java...
+    }
+
+    @Override
+    public Optional<SpringEntity> getDominantSpring() {
+        return this.dominantS; // Java...
     }
 
     @Override

--- a/src/main/java/dev/murad/shipping/entity/custom/barge/AbstractBargeEntity.java
+++ b/src/main/java/dev/murad/shipping/entity/custom/barge/AbstractBargeEntity.java
@@ -5,6 +5,7 @@ import com.mojang.datafixers.util.Pair;
 import dev.murad.shipping.util.LinkableEntity;
 import dev.murad.shipping.entity.custom.SpringEntity;
 import dev.murad.shipping.entity.custom.VesselEntity;
+import dev.murad.shipping.util.SpringableEntity;
 import dev.murad.shipping.util.Train;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.world.InteractionHand;
@@ -85,14 +86,24 @@ public abstract class AbstractBargeEntity extends VesselEntity implements Linkab
     }
 
     @Override
-    public void setDominated(LinkableEntity entity, SpringEntity spring) {
-        this.dominated = Optional.of(new Pair<>(entity, spring));
+    public void setDominated(LinkableEntity entity) {
+        this.dominated = Optional.of((SpringableEntity) entity);
     }
 
     @Override
-    public void setDominant(LinkableEntity entity, SpringEntity spring) {
+    public void setDominatedSpring(SpringEntity spring) {
+        this.dominatedS = Optional.of(spring);
+    }
+
+    @Override
+    public void setDominant(LinkableEntity entity) {
         this.setTrain(entity.getTrain());
-        this.dominant = Optional.of(new Pair<>(entity, spring));
+        this.dominant = Optional.of((SpringableEntity) entity);
+    }
+
+    @Override
+    public void setDominantSpring(SpringEntity spring) {
+        this.dominantS = Optional.of(spring);
     }
 
     @Override
@@ -101,6 +112,7 @@ public abstract class AbstractBargeEntity extends VesselEntity implements Linkab
             return;
         }
         this.dominated = Optional.empty();
+        this.dominatedS = Optional.empty();
         this.train.setTail(this);
     }
 
@@ -110,6 +122,7 @@ public abstract class AbstractBargeEntity extends VesselEntity implements Linkab
             return;
         }
         this.dominant = Optional.empty();
+        this.dominantS = Optional.empty();
         this.setTrain(new Train(this));
     }
 
@@ -119,21 +132,21 @@ public abstract class AbstractBargeEntity extends VesselEntity implements Linkab
         train.setTail(this);
         dominated.ifPresent(dominated -> {
             // avoid recursion loops
-            if(!dominated.getFirst().getTrain().equals(train)){
-                dominated.getFirst().setTrain(train);
+            if(!dominated.getTrain().equals(train)){
+                dominated.setTrain(train);
             }
         });
     }
 
     @Override
     public void remove(RemovalReason r){
-        handleSpringableKill();
+        handleLinkableKill();
         super.remove(r);
     }
 
     // hack to disable hoppers
     public boolean isDockable() {
-        return this.dominant.map(dom -> this.distanceToSqr((Entity) dom.getFirst()) < 1.1).orElse(true);
+        return this.dominant.map(dom -> this.distanceToSqr((Entity) dom) < 1.1).orElse(true);
     }
 
     public boolean allowDockInterface(){

--- a/src/main/java/dev/murad/shipping/entity/custom/tug/AbstractTugEntity.java
+++ b/src/main/java/dev/murad/shipping/entity/custom/tug/AbstractTugEntity.java
@@ -31,7 +31,6 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
 import net.minecraft.world.entity.animal.WaterAnimal;
-import net.minecraft.world.entity.boss.EnderDragonPart;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -55,7 +54,7 @@ import java.util.Random;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
-public abstract class AbstractTugEntity extends VesselEntity implements LinkableEntityHead, Container, WorldlyContainer {
+public abstract class AbstractTugEntity extends VesselEntity implements LinkableEntityHead, SpringableEntity, Container, WorldlyContainer {
 
     // CONTAINER STUFF
     protected final ItemStackHandler itemHandler = createHandler();
@@ -437,12 +436,22 @@ public abstract class AbstractTugEntity extends VesselEntity implements Linkable
     }
 
     @Override
-    public void setDominated(LinkableEntity entity, SpringEntity spring) {
-        this.dominated = Optional.of(new Pair<>(entity, spring));
+    public void setDominated(LinkableEntity entity) {
+        this.dominated = Optional.of((SpringableEntity) entity);
     }
 
     @Override
-    public void setDominant(LinkableEntity entity, SpringEntity spring) {
+    public void setDominatedSpring(SpringEntity spring) {
+        this.dominatedS = Optional.of(spring);
+    }
+
+    @Override
+    public void setDominant(LinkableEntity entity) {
+
+    }
+
+    @Override
+    public void setDominantSpring(SpringEntity entity) {
 
     }
 
@@ -481,7 +490,7 @@ public abstract class AbstractTugEntity extends VesselEntity implements Linkable
         if (!this.level.isClientSide) {
             Containers.dropContents(this.level, this, this);
         }
-        handleSpringableKill();
+        handleLinkableKill();
         super.remove(r);
     }
 

--- a/src/main/java/dev/murad/shipping/entity/render/VesselRenderer.java
+++ b/src/main/java/dev/murad/shipping/entity/render/VesselRenderer.java
@@ -67,7 +67,7 @@ public abstract class VesselRenderer<T extends VesselEntity> extends EntityRende
 
     private void getAndRenderChain(T bargeEntity, PoseStack matrixStack, MultiBufferSource buffer, int p_225623_6_) {
         if(bargeEntity.getDominant().isPresent()) {
-            double dist = ((Entity) bargeEntity.getDominant().get().getFirst()).distanceTo(bargeEntity);
+            double dist = ((Entity) bargeEntity.getDominant().get()).distanceTo(bargeEntity);
             VertexConsumer ivertexbuilderChain = buffer.getBuffer(chainModel.renderType(CHAIN_TEXTURE));
             int segments = (int) Math.ceil(dist * 4);
             matrixStack.pushPose();
@@ -96,10 +96,10 @@ public abstract class VesselRenderer<T extends VesselEntity> extends EntityRende
     @Override
     public boolean shouldRender(T p_225626_1_, Frustum p_225626_2_, double p_225626_3_, double p_225626_5_, double p_225626_7_) {
         if(p_225626_1_.getDominant().isPresent()){
-            if(((Entity) p_225626_1_.getDominant().get().getFirst()).shouldRender(p_225626_3_, p_225626_5_, p_225626_7_)){
+            if(((Entity) p_225626_1_.getDominant().get()).shouldRender(p_225626_3_, p_225626_5_, p_225626_7_)){
                 return true;
             }
-            if(p_225626_1_.getDominant().get().getSecond().shouldRender(p_225626_3_, p_225626_5_, p_225626_7_)){
+            if(p_225626_1_.getDominantSpring().get().shouldRender(p_225626_3_, p_225626_5_, p_225626_7_)){
                 return true;
             }
         }

--- a/src/main/java/dev/murad/shipping/event/ForgeEventHandler.java
+++ b/src/main/java/dev/murad/shipping/event/ForgeEventHandler.java
@@ -1,9 +1,11 @@
 package dev.murad.shipping.event;
 
 import dev.murad.shipping.ShippingMod;
+import dev.murad.shipping.entity.custom.SpringEntity;
 import dev.murad.shipping.item.SpringItem;
 import dev.murad.shipping.util.EntitySpringAPI;
 import dev.murad.shipping.util.LinkableEntity;
+import dev.murad.shipping.util.SpringableEntity;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.Item;
@@ -32,8 +34,7 @@ public class ForgeEventHandler {
     private static void handleEvent(PlayerInteractEvent event, Entity target) {
         if(!event.getItemStack().isEmpty()) {
             Item item = event.getItemStack().getItem();
-            if(item instanceof SpringItem) {
-                SpringItem springItem = (SpringItem) item;
+            if(item instanceof SpringItem springItem) {
                 if(EntitySpringAPI.isValidTarget(target)) {
                     springItem.onUsedOnEntity(event.getItemStack(), event.getPlayer(), event.getWorld(), target);
                     event.setCanceled(true);
@@ -42,8 +43,8 @@ public class ForgeEventHandler {
             }
 
             if(item instanceof ShearsItem) {
-                if(target instanceof LinkableEntity) {
-                    ((LinkableEntity) target).getDominant().ifPresent(pair -> pair.getSecond().kill());
+                if(target instanceof SpringableEntity v) {
+                    v.handleShearsCut();
                     event.setCanceled(true);
                     event.setCancellationResult(InteractionResult.SUCCESS);
                 }

--- a/src/main/java/dev/murad/shipping/util/LinkableEntity.java
+++ b/src/main/java/dev/murad/shipping/util/LinkableEntity.java
@@ -13,28 +13,29 @@ import java.util.stream.Stream;
 
 public interface LinkableEntity {
 
-    Optional<Pair<LinkableEntity, SpringEntity>> getDominated();
-    Optional<Pair<LinkableEntity, SpringEntity>> getDominant();
-    void setDominated(LinkableEntity entity, SpringEntity spring);
-    void setDominant(LinkableEntity entity, SpringEntity spring);
+    Optional<LinkableEntity> getDominated();
+    Optional<LinkableEntity> getDominant();
+    void setDominated(LinkableEntity entity);
+    void setDominant(LinkableEntity entity);
     void removeDominated();
     void removeDominant();
+    void handleShearsCut();
     Train getTrain();
     boolean linkEntities(Player player, Entity target);
     void setTrain(Train train);
     boolean hasWaterOnSides();
 
-    default void handleSpringableKill(){
-        this.getDominated().map(Pair::getFirst).ifPresent(LinkableEntity::removeDominant);
-        this.getDominant().map(Pair::getFirst).ifPresent(LinkableEntity::removeDominated);
+    default void handleLinkableKill(){
+        this.getDominated().ifPresent(LinkableEntity::removeDominant);
+        this.getDominant().ifPresent(LinkableEntity::removeDominated);
     }
 
     default boolean checkNoLoopsDominated(){
-        return checkNoLoopsHelper(this, (entity -> entity.getDominated().map(Pair::getFirst)), new HashSet<>());
+        return checkNoLoopsHelper(this, (LinkableEntity::getDominated), new HashSet<>());
     }
 
     default boolean checkNoLoopsDominant(){
-        return checkNoLoopsHelper(this, (entity -> entity.getDominant().map(Pair::getFirst)), new HashSet<>());
+        return checkNoLoopsHelper(this, (LinkableEntity::getDominant), new HashSet<>());
     }
 
     default boolean checkNoLoopsHelper(LinkableEntity entity, Function<LinkableEntity, Optional<LinkableEntity>> next, Set<LinkableEntity> set){
@@ -54,7 +55,7 @@ public interface LinkableEntity {
         Stream<U> ofThis = Stream.of(function.apply(this));
 
         return checkNoLoopsDominant() ? ofThis : this.getDominant().map(dom ->
-                Stream.concat(ofThis, dom.getFirst().applyWithDominant(function))
+                Stream.concat(ofThis, dom.applyWithDominant(function))
         ).orElse(ofThis);
 
     }
@@ -63,24 +64,8 @@ public interface LinkableEntity {
         Stream<U> ofThis = Stream.of(function.apply(this));
 
         return checkNoLoopsDominated() ? ofThis : this.getDominated().map(dom ->
-                Stream.concat(ofThis, dom.getFirst().applyWithDominated(function))
+                Stream.concat(ofThis, dom.applyWithDominated(function))
         ).orElse(ofThis);
-
-    }
-
-    default void tickSpringAliveCheck(){
-        this.getDominant().map(Pair::getSecond).map(Entity::isAlive).ifPresent(alive -> {
-            if(!alive){
-                this.removeDominant();
-            }
-        });
-
-        this.getDominated().map(Pair::getSecond).map(Entity::isAlive).ifPresent(alive -> {
-            if(!alive){
-                this.removeDominated();
-            }
-        });
-
 
     }
 }

--- a/src/main/java/dev/murad/shipping/util/SpringableEntity.java
+++ b/src/main/java/dev/murad/shipping/util/SpringableEntity.java
@@ -1,0 +1,47 @@
+package dev.murad.shipping.util;
+
+
+import dev.murad.shipping.entity.custom.SpringEntity;
+import net.minecraft.world.entity.Entity;
+
+import java.util.Optional;
+
+
+public interface SpringableEntity extends LinkableEntity {
+    void setDominatedSpring(SpringEntity s);
+    void setDominantSpring(SpringEntity s);
+
+    Optional<SpringEntity> getDominatedSpring();
+    Optional<SpringEntity> getDominantSpring();
+
+
+    @Override
+    default void handleShearsCut() {
+        getDominantSpring().ifPresent(Entity::kill);
+    }
+
+    default void tickSpringAliveCheck(){
+        this.getDominantSpring().map(Entity::isAlive).ifPresent(alive -> {
+            if(!alive){
+                this.removeDominant();
+            }
+        });
+
+        this.getDominatedSpring().map(Entity::isAlive).ifPresent(alive -> {
+            if(!alive){
+                this.removeDominated();
+            }
+        });
+    }
+
+    default void setDominated(LinkableEntity entity, SpringEntity spring) {
+        setDominated(entity);
+        setDominatedSpring(spring);
+    }
+
+    default void setDominant(LinkableEntity entity, SpringEntity spring) {
+        setDominant(entity);
+        setDominantSpring(spring);
+    }
+
+}

--- a/src/main/java/dev/murad/shipping/util/Train.java
+++ b/src/main/java/dev/murad/shipping/util/Train.java
@@ -1,11 +1,10 @@
 package dev.murad.shipping.util;
 
-import com.mojang.datafixers.util.Pair;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class Train {
     private final Optional<LinkableEntityHead> tug;
     private LinkableEntity tail;
@@ -37,7 +36,7 @@ public class Train {
         if(this.head.checkNoLoopsDominated()) {
             // just in case - to avoid crashing the world.
             this.head.removeDominated();
-            this.head.getDominated().map(Pair::getFirst).ifPresent(LinkableEntity::removeDominant);
+            this.head.getDominated().ifPresent(LinkableEntity::removeDominant);
             return new ArrayList<>();
         }
         return tug.map(tugEntity -> {
@@ -50,7 +49,7 @@ public class Train {
     }
 
     public Optional<LinkableEntity> getNext(LinkableEntity entity){
-        return entity.getDominated().map(Pair::getFirst).map(e -> e);
+        return entity.getDominated();
     }
 
     public void setHead(LinkableEntity head) {


### PR DESCRIPTION
This lets you use linking logic without spring entity that has vessel specific code. Spring item will link train cars directly. 