### PR TITLE
Bump version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs  = -Xmx3G
 org.gradle.daemon   = false
 
 # Core properties
-mod_version         = 1.1.2
+mod_version         = 1.1.3
 mod_group           = dev.murad.littlelogistics
 mod_id              = littlelogistics
 mod_title           = Little Logistics


### PR DESCRIPTION
Release 1.1.3

TODO: fix this so that version string is inferred from git tags, so we don't have to open pull request every time we need to publish
