### PR TITLE
main-1.18 compatibility with Create 0.5.1a+ attempt 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,10 +169,10 @@ dependencies {
 //    runtimeOnly fg.deobf("com.teamcofh:thermal_expansion:1.16.5-1.4.2.4")
 
     // create
-    compileOnly fg.deobf("com.jozufozu.flywheel:Flywheel-Forge:${rootProject.flywheel_version}")
-    compileOnly fg.deobf("com.simibubi.create:Create:${rootProject.create_version}")
-//    runtimeOnly fg.deobf("com.jozufozu.flywheel:Flywheel-Forge:${rootProject.flywheel_version}")
-//    runtimeOnly fg.deobf("com.simibubi.create:Create:${rootProject.create_version}")
+    compileOnly fg.deobf("com.jozufozu.flywheel:flywheel-forge-1.18.2:${rootProject.flywheel_version}")
+    compileOnly fg.deobf("com.simibubi.create:create-1.18.2:${rootProject.create_version}:all")
+//    runtimeOnly fg.deobf("com.jozufozu.flywheel:flywheel-forge-1.18.2:${rootProject.flywheel_version}")
+//    runtimeOnly fg.deobf("com.simibubi.create:create-1.18.2:${rootProject.create_version}:all")
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..
@@ -212,7 +212,8 @@ processResources {
                 "mod_license":              project.mod_license,
                 "mc_version_range":         project.mc_version_range,
                 "forge_version_range":      project.forge_version_range,
-                "patchouli_version_range":  project.patchouli_version_range
+                "patchouli_version_range":  project.patchouli_version_range,
+                "create_version_range":     project.create_version_range
     }
     filesMatching("pack.mcmeta") {
         expand "mod_id": project.mod_id
@@ -270,4 +271,19 @@ repositories {
         name 'tterrag maven'
         url 'https://maven.tterrag.com'
     }
+
+    maven {
+        // location of the maven for Curios API
+        url = "https://maven.theillusivec4.top/"
+    }
+
+    maven {
+        // location of maven for CC: Tweaked
+        name = "squiddev"
+        url = "https://squiddev.cc/maven/"
+        content {
+            includeGroup "org.squiddev"
+        }
+    }
+
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ mod_icon_path       = modbanner.png
 
 mc_version          = 1.18.2
 mc_version_range    = [1.18.2,1.19)
-forge_version       = 40.0.34
+forge_version       = 40.2.4
 forge_version_range = [40,)
 
 # Mod dependencies
@@ -43,9 +43,9 @@ patchouli_version   = 1.18.2-66
 patchouli_version_range = [1.18,)
 
 # Mod compat
-create_version          = mc1.18.2_v0.4.1+111
-flywheel_version        = 1.18-0.6.2.64
-
+create_version          = 0.5.1.a-279
+create_version_range    = [0.5.1,)
+flywheel_version        = 0.6.8.a-99
 # Mapping versions (official, parchment)
 mappings_channel = parchment
 mappings_version = 2022.03.13-1.18.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,8 +24,7 @@ You should have received a copy of the GNU General Public License along with thi
 Acknowledgements:\n\
 For Entity Spring: https://github.com/jglrxavpok\n\
 For logo help: https://github.com/tenmyouji\n\
-For artwork: https://twitter.com/danfront2\n\
-\n\
+For artwork: https://twitter.com/danfront2
 
 mod_url             = https://littlelogistics.murad.dev
 mod_author          = Murad Akhundov and EDToaster

--- a/src/main/java/dev/murad/shipping/compatibility/create/CapabilityInjector.java
+++ b/src/main/java/dev/murad/shipping/compatibility/create/CapabilityInjector.java
@@ -1,7 +1,7 @@
 package dev.murad.shipping.compatibility.create;
 
-import com.simibubi.create.content.contraptions.components.structureMovement.train.capability.CapabilityMinecartController;
-import com.simibubi.create.content.contraptions.components.structureMovement.train.capability.MinecartController;
+import com.simibubi.create.content.contraptions.minecart.capability.CapabilityMinecartController;
+import com.simibubi.create.content.contraptions.minecart.capability.MinecartController;
 import dev.murad.shipping.capability.StallingCapability;
 import dev.murad.shipping.entity.custom.train.wagon.SeaterCarEntity;
 import net.minecraftforge.common.capabilities.Capability;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -60,3 +60,10 @@ description='''${mod_description}'''
     versionRange="${patchouli_version_range}"
     ordering="NONE"
     side="BOTH"
+
+[[dependencies.shipping]]
+modId="create"
+mandatory=false
+versionRange="${create_version_range}"
+ordering="NONE"
+side="BOTH"


### PR DESCRIPTION
Ok - 3rd time's the charm with this PR?  xD

This *does* build and load to game.  Swear to god.

As instructed the mod version entry was left alone.  The locations of the create and flywheel locations are updated in build.gradle - and additional mavens for new things required for the build were added. A Create mod optional dependency was added so that a minimum version required could be set.  