### PR TITLE
release-prep 1.21.1: CI for JDK 21 + beta tags, and confirmed release-readiness fixes

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: Publish artifact
         env:
@@ -28,7 +28,7 @@ jobs:
         # we can get the release name.
         run: |
           NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
-          NEW_VERSION_TRUNC=$(echo "${NEW_VERSION}" | grep -oP 'mc[0-9]+\.[0-9]+(?:\.[0-9]+)?-v\K[0-9\.a-zA-Z]+')
+          NEW_VERSION_TRUNC=$(echo "${NEW_VERSION}" | grep -oP 'mc[0-9]+\.[0-9]+(?:\.[0-9]+)?-v\K[0-9.a-zA-Z-]+')
           echo "New version: ${NEW_VERSION}"
           echo "Truncated version: ${NEW_VERSION_TRUNC}"
           [ -z "${NEW_VERSION_TRUNC}" ] && exit 1

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: Verify artifact
         run: |

--- a/src/main/java/dev/murad/shipping/ShippingConfig.java
+++ b/src/main/java/dev/murad/shipping/ShippingConfig.java
@@ -126,7 +126,7 @@ public class ShippingConfig {
                 BUILDER.push("barge");
                 FISHING_TREASURE_CHANCE_MODIFIER =
                         BUILDER.comment("Modify the chance of using the treasure loot table with the auto fishing barge, other factors such as depth and overfishing still play a role. " +
-                                        "Default 0.02.")
+                                        "Default 0.04.")
                                 .define("fishingTreasureChance", 0.04);
                 FISHING_LOOT_TABLE =
                         BUILDER.comment("Loot table to use when fishing barge catches a fish. Change to 'minecraft:gameplay/fishing' if some modded fish aren't being caught. Defaults to 'minecraft:gameplay/fishing/fish'.")
@@ -172,7 +172,7 @@ public class ShippingConfig {
             {
                 BUILDER.push("general");
                 TRAIN_MAX_SPEED =
-                        BUILDER.comment("Max speed that trains can be accelerated to. High speed may cause chunk loading lag or issues, not advised for servers or packs. Default 0.25, max is 1")
+                        BUILDER.comment("Max speed that trains can be accelerated to. High speed may cause chunk loading lag or issues, not advised for servers or packs. Default 0.6, max is 1")
                                 .defineInRange("trainMaxSpeed", 0.6, 0.01, 1);
 
                 TRAIN_EXEMPT_DAMAGE_SOURCES = BUILDER.comment("Damage sources that trains are invulnerable to")
@@ -185,7 +185,7 @@ public class ShippingConfig {
             {
                 BUILDER.push("locomotive");
                 LOCO_BASE_SPEED =
-                        BUILDER.comment("Locomotive base speed. High speed may cause chunk loading lag or issues, not advised for servers or packs. Default 0.2, max is 0.9")
+                        BUILDER.comment("Locomotive base speed. High speed may cause chunk loading lag or issues, not advised for servers or packs. Default 0.5, max is 0.9")
                                 .defineInRange("locoBaseSpeed", 0.5, 0.01, 0.9);
 
                 STEAM_LOCO_FUEL_MULTIPLIER =

--- a/src/main/java/dev/murad/shipping/block/vesseldetector/VesselDetectorTileEntity.java
+++ b/src/main/java/dev/murad/shipping/block/vesseldetector/VesselDetectorTileEntity.java
@@ -41,7 +41,6 @@ public class VesselDetectorTileEntity extends BlockEntity  {
                 (e) -> e instanceof VesselEntity || e instanceof AbstractTrainCarEntity).isEmpty();
         boolean previousPowered = this.getBlockState().getValue(VesselDetectorBlock.POWERED);
 
-        this.getBlockState().setValue(VesselDetectorBlock.POWERED, found);
         level.setBlockAndUpdate(getBlockPos(), getBlockState().setValue(VesselDetectorBlock.POWERED, found));
 
         if (found != previousPowered) {

--- a/src/main/java/dev/murad/shipping/entity/custom/train/AbstractTrainCarEntity.java
+++ b/src/main/java/dev/murad/shipping/entity/custom/train/AbstractTrainCarEntity.java
@@ -66,7 +66,6 @@ public abstract class AbstractTrainCarEntity extends AbstractMinecart implements
     public static final EntityDataAccessor<Integer> DOMINANT_ID = SynchedEntityData.defineId(AbstractTrainCarEntity.class, EntityDataSerializers.INT);
     public static final EntityDataAccessor<Integer> DOMINATED_ID = SynchedEntityData.defineId(AbstractTrainCarEntity.class, EntityDataSerializers.INT);
     protected final LinkingHandler<AbstractTrainCarEntity> linkingHandler = new LinkingHandler<>(this, AbstractTrainCarEntity.class, DOMINANT_ID, DOMINATED_ID);
-    protected static double TRAIN_SPEED = ShippingConfig.Server.TRAIN_MAX_SPEED.get();
     protected final RailHelper railHelper;
     @Nullable
     private BlockPos lastRailPosition;

--- a/src/main/java/dev/murad/shipping/entity/custom/train/locomotive/EnergyLocomotiveEntity.java
+++ b/src/main/java/dev/murad/shipping/entity/custom/train/locomotive/EnergyLocomotiveEntity.java
@@ -76,7 +76,7 @@ public class EnergyLocomotiveEntity extends AbstractLocomotiveEntity implements 
 
     @Override
     public void remove(RemovalReason r) {
-        if(!this.level().isClientSide){
+        if(!this.level().isClientSide && r != RemovalReason.UNLOADED_TO_CHUNK){
             Containers.dropContents(this.level(), this, this);
         }
         super.remove(r);

--- a/src/main/java/dev/murad/shipping/entity/custom/train/locomotive/SteamLocomotiveEntity.java
+++ b/src/main/java/dev/murad/shipping/entity/custom/train/locomotive/SteamLocomotiveEntity.java
@@ -107,7 +107,7 @@ public class SteamLocomotiveEntity extends AbstractLocomotiveEntity implements I
 
     @Override
     public void remove(RemovalReason r) {
-        if(!this.level().isClientSide){
+        if(!this.level().isClientSide && r != RemovalReason.UNLOADED_TO_CHUNK){
             Containers.dropContents(this.level(), this, this);
         }
         super.remove(r);

--- a/src/main/java/dev/murad/shipping/entity/custom/train/wagon/ChestCarEntity.java
+++ b/src/main/java/dev/murad/shipping/entity/custom/train/wagon/ChestCarEntity.java
@@ -32,7 +32,7 @@ public class ChestCarEntity extends AbstractWagonEntity implements ItemHandlerVa
 
     @Override
     public void remove(RemovalReason r) {
-        if (!this.level().isClientSide) {
+        if (!this.level().isClientSide && r != RemovalReason.UNLOADED_TO_CHUNK) {
             Containers.dropContents(this.level(), this, this);
         }
         super.remove(r);

--- a/src/main/java/dev/murad/shipping/entity/custom/vessel/barge/ChestBargeEntity.java
+++ b/src/main/java/dev/murad/shipping/entity/custom/vessel/barge/ChestBargeEntity.java
@@ -40,7 +40,7 @@ public class ChestBargeEntity extends AbstractBargeEntity implements Container, 
 
     @Override
     public void remove(RemovalReason r) {
-        if (!this.level().isClientSide) {
+        if (!this.level().isClientSide && r != RemovalReason.UNLOADED_TO_CHUNK) {
             Containers.dropContents(this.level(), this, this);
         }
         super.remove(r);

--- a/src/main/java/dev/murad/shipping/entity/custom/vessel/barge/ChunkLoaderBargeEntity.java
+++ b/src/main/java/dev/murad/shipping/entity/custom/vessel/barge/ChunkLoaderBargeEntity.java
@@ -42,11 +42,13 @@ public class ChunkLoaderBargeEntity extends AbstractBargeEntity {
 
     @Override
     public void addAdditionalSaveData(@NotNull CompoundTag p_213281_1_) {
+        super.addAdditionalSaveData(p_213281_1_);
         mobileChunkLoader.addAdditionalSaveData(p_213281_1_);
     }
 
     @Override
     public void readAdditionalSaveData(@NotNull CompoundTag p_70037_1_) {
+        super.readAdditionalSaveData(p_70037_1_);
         mobileChunkLoader.readAdditionalSaveData(p_70037_1_);
     }
 

--- a/src/main/java/dev/murad/shipping/entity/render/barge/AbstractVesselRenderer.java
+++ b/src/main/java/dev/murad/shipping/entity/render/barge/AbstractVesselRenderer.java
@@ -117,9 +117,6 @@ public abstract class AbstractVesselRenderer<T extends VesselEntity> extends Ent
             if(p_225626_1_.getLeader().get().shouldRender(p_225626_3_, p_225626_5_, p_225626_7_)){
                 return true;
             }
-            if(p_225626_1_.getLeader().get().shouldRender(p_225626_3_, p_225626_5_, p_225626_7_)){
-                return true;
-            }
         }
         return super.shouldRender(p_225626_1_, p_225626_2_, p_225626_3_, p_225626_5_, p_225626_7_);
     }

--- a/src/main/java/dev/murad/shipping/event/ForgeClientEventHandler.java
+++ b/src/main/java/dev/murad/shipping/event/ForgeClientEventHandler.java
@@ -588,15 +588,17 @@ public class ForgeClientEventHandler {
             }
             var camPos = Minecraft.getInstance().getEntityRenderDispatcher().camera.getPosition();
             var pose = event.getPoseStack();
-            var buffer = MultiBufferSource.immediate(new ByteBufferBuilder(16_384));
-            LocoRoute locoRoute = LocoRouteItem.getRoute(stack);
+            try (ByteBufferBuilder byteBufferBuilder = new ByteBufferBuilder(16_384)) {
+                var buffer = MultiBufferSource.immediate(byteBufferBuilder);
+                LocoRoute locoRoute = LocoRouteItem.getRoute(stack);
 
-            renderLocoRoutePath(pose, buffer, camPos, player.level(), locoRoute);
-            renderLocoRouteNodes(pose, buffer, camPos, player.level(), locoRoute, new RouteColour(1.0F, 0.6F, 0.2F));
-            renderPendingLocoRoutePreview(pose, buffer, camPos, locoRoute, player.level());
-            renderLocoRouteTarget(pose, buffer, camPos, player, locoRoute);
+                renderLocoRoutePath(pose, buffer, camPos, player.level(), locoRoute);
+                renderLocoRouteNodes(pose, buffer, camPos, player.level(), locoRoute, new RouteColour(1.0F, 0.6F, 0.2F));
+                renderPendingLocoRoutePreview(pose, buffer, camPos, locoRoute, player.level());
+                renderLocoRouteTarget(pose, buffer, camPos, player, locoRoute);
 
-            buffer.endBatch();
+                buffer.endBatch();
+            }
         } else if (stack.getItem().equals(ModItems.TUG_ROUTE.get())){
             if(ShippingConfig.Client.DISABLE_ROUTE_MARKERS.get()){
                 return false;
@@ -838,85 +840,87 @@ public class ForgeClientEventHandler {
         var camera = Minecraft.getInstance().getEntityRenderDispatcher().camera;
         var camPos = camera.getPosition();
         var pose = event.getPoseStack();
-        var buffer = MultiBufferSource.immediate(new ByteBufferBuilder(1536));
-        TugRoute route = TugRouteItem.getRoute(stack);
-        List<PreviewPoint> previewPoints = flattenTugRoutePreviewPoints(route);
-        Set<BlockPos> replacedSegmentPoints = getReplacedSegmentPoints(route);
-        boolean completionTarget = isCompletionTarget(route);
-        float routeRed = completionTarget ? 0.2f : 1.0f;
-        float routeGreen = completionTarget ? 1.0f : 0.6f;
-        float routeBlue = 0.2f;
+        try (ByteBufferBuilder byteBufferBuilder = new ByteBufferBuilder(1536)) {
+            var buffer = MultiBufferSource.immediate(byteBufferBuilder);
+            TugRoute route = TugRouteItem.getRoute(stack);
+            List<PreviewPoint> previewPoints = flattenTugRoutePreviewPoints(route);
+            Set<BlockPos> replacedSegmentPoints = getReplacedSegmentPoints(route);
+            boolean completionTarget = isCompletionTarget(route);
+            float routeRed = completionTarget ? 0.2f : 1.0f;
+            float routeGreen = completionTarget ? 1.0f : 0.6f;
+            float routeBlue = 0.2f;
 
-        double travelled = 0.0D;
-        double nextArrowDistance = TUG_ROUTE_ARROW_SPACING * 0.5D;
-        for (int pointIndex = 1; pointIndex < previewPoints.size(); pointIndex++) {
-            PreviewPoint from = previewPoints.get(pointIndex - 1);
-            PreviewPoint to = previewPoints.get(pointIndex);
-            PreviewSegment segment = trimPreviewSegment(from, to);
-            if (segment == null) {
-                travelled += from.position().distanceTo(to.position());
-                continue;
-            }
-
-            Vec3 leftFrom = segment.from().add(segment.side().scale(TUG_ROUTE_RAIL_OFFSET));
-            Vec3 leftTo = segment.to().add(segment.side().scale(TUG_ROUTE_RAIL_OFFSET));
-            Vec3 rightFrom = segment.from().subtract(segment.side().scale(TUG_ROUTE_RAIL_OFFSET));
-            Vec3 rightTo = segment.to().subtract(segment.side().scale(TUG_ROUTE_RAIL_OFFSET));
-            boolean isReplacedSegment = replacedSegmentPoints.contains(toBlockPos(from.position()))
-                && replacedSegmentPoints.contains(toBlockPos(to.position()));
-            float segmentRed = isReplacedSegment ? 0.0f : routeRed;
-            float segmentGreen = isReplacedSegment ? 0.0f : routeGreen;
-            float segmentBlue = isReplacedSegment ? 0.0f : routeBlue;
-            float railAlpha = RouteMarkerRenderer.computeAlpha(segment.from().add(segment.to()).scale(0.5D), camPos);
-            if (railAlpha > 0.0f) {
-                var lineBuffer = buffer.getBuffer(ModRenderType.LINES);
-                RouteMarkerRenderer.renderLine(pose, lineBuffer, camPos, leftFrom, leftTo, segmentRed, segmentGreen, segmentBlue, railAlpha);
-                RouteMarkerRenderer.renderLine(pose, lineBuffer, camPos, rightFrom, rightTo, segmentRed, segmentGreen, segmentBlue, railAlpha);
-            }
-
-            double segmentLength = segment.length();
-            while (segmentLength > 1.0E-6D && travelled + segmentLength >= nextArrowDistance) {
-                double ratio = (nextArrowDistance - travelled) / segmentLength;
-                Vec3 arrowCenter = segment.from().lerp(segment.to(), ratio);
-                float arrowAlpha = RouteMarkerRenderer.computeAlpha(arrowCenter, camPos);
-                if (arrowAlpha > 0.0f && isArrowClearOfCorners(arrowCenter, segment.forward(), segment.side(), previewPoints)) {
-                    renderTugRouteArrow(pose, buffer.getBuffer(ModRenderType.LINES), camPos, arrowCenter, segment.forward(), segment.side(), segmentRed, segmentGreen, segmentBlue, arrowAlpha);
+            double travelled = 0.0D;
+            double nextArrowDistance = TUG_ROUTE_ARROW_SPACING * 0.5D;
+            for (int pointIndex = 1; pointIndex < previewPoints.size(); pointIndex++) {
+                PreviewPoint from = previewPoints.get(pointIndex - 1);
+                PreviewPoint to = previewPoints.get(pointIndex);
+                PreviewSegment segment = trimPreviewSegment(from, to);
+                if (segment == null) {
+                    travelled += from.position().distanceTo(to.position());
+                    continue;
                 }
-                nextArrowDistance += TUG_ROUTE_ARROW_SPACING;
+
+                Vec3 leftFrom = segment.from().add(segment.side().scale(TUG_ROUTE_RAIL_OFFSET));
+                Vec3 leftTo = segment.to().add(segment.side().scale(TUG_ROUTE_RAIL_OFFSET));
+                Vec3 rightFrom = segment.from().subtract(segment.side().scale(TUG_ROUTE_RAIL_OFFSET));
+                Vec3 rightTo = segment.to().subtract(segment.side().scale(TUG_ROUTE_RAIL_OFFSET));
+                boolean isReplacedSegment = replacedSegmentPoints.contains(toBlockPos(from.position()))
+                    && replacedSegmentPoints.contains(toBlockPos(to.position()));
+                float segmentRed = isReplacedSegment ? 0.0f : routeRed;
+                float segmentGreen = isReplacedSegment ? 0.0f : routeGreen;
+                float segmentBlue = isReplacedSegment ? 0.0f : routeBlue;
+                float railAlpha = RouteMarkerRenderer.computeAlpha(segment.from().add(segment.to()).scale(0.5D), camPos);
+                if (railAlpha > 0.0f) {
+                    var lineBuffer = buffer.getBuffer(ModRenderType.LINES);
+                    RouteMarkerRenderer.renderLine(pose, lineBuffer, camPos, leftFrom, leftTo, segmentRed, segmentGreen, segmentBlue, railAlpha);
+                    RouteMarkerRenderer.renderLine(pose, lineBuffer, camPos, rightFrom, rightTo, segmentRed, segmentGreen, segmentBlue, railAlpha);
+                }
+
+                double segmentLength = segment.length();
+                while (segmentLength > 1.0E-6D && travelled + segmentLength >= nextArrowDistance) {
+                    double ratio = (nextArrowDistance - travelled) / segmentLength;
+                    Vec3 arrowCenter = segment.from().lerp(segment.to(), ratio);
+                    float arrowAlpha = RouteMarkerRenderer.computeAlpha(arrowCenter, camPos);
+                    if (arrowAlpha > 0.0f && isArrowClearOfCorners(arrowCenter, segment.forward(), segment.side(), previewPoints)) {
+                        renderTugRouteArrow(pose, buffer.getBuffer(ModRenderType.LINES), camPos, arrowCenter, segment.forward(), segment.side(), segmentRed, segmentGreen, segmentBlue, arrowAlpha);
+                    }
+                    nextArrowDistance += TUG_ROUTE_ARROW_SPACING;
+                }
+
+                travelled += segmentLength;
             }
 
-            travelled += segmentLength;
-        }
+            renderNonNodeCorners(pose, buffer, camPos, previewPoints, routeRed, routeGreen, routeBlue);
 
-        renderNonNodeCorners(pose, buffer, camPos, previewPoints, routeRed, routeGreen, routeBlue);
-
-        if (route.isInserting() && route.getNextInsertionIndex() > 0) {
-            int replacedSegmentIndex = route.getNextInsertionIndex() - 1;
-            if (replacedSegmentIndex < route.getSegments().size()) {
-                renderTugRouteSegment(pose, buffer, camPos, route.getSegments().get(replacedSegmentIndex), 0.0f, 0.0f, 0.0f);
+            if (route.isInserting() && route.getNextInsertionIndex() > 0) {
+                int replacedSegmentIndex = route.getNextInsertionIndex() - 1;
+                if (replacedSegmentIndex < route.getSegments().size()) {
+                    renderTugRouteSegment(pose, buffer, camPos, route.getSegments().get(replacedSegmentIndex), 0.0f, 0.0f, 0.0f);
+                }
             }
-        }
 
-        for (int i = 0, routeSize = route.size(); i < routeSize; i++) {
-            TugRouteNode node = route.get(i);
-            Vec3 nodePos = toWaterSurface(Vec3.atCenterOf(node.toBlockPos()));
-            float alpha = RouteMarkerRenderer.computeAlpha(nodePos, camPos);
-            if (alpha <= 0.0f) {
-                continue;
+            for (int i = 0, routeSize = route.size(); i < routeSize; i++) {
+                TugRouteNode node = route.get(i);
+                Vec3 nodePos = toWaterSurface(Vec3.atCenterOf(node.toBlockPos()));
+                float alpha = RouteMarkerRenderer.computeAlpha(nodePos, camPos);
+                if (alpha <= 0.0f) {
+                    continue;
+                }
+                var lineBuffer = buffer.getBuffer(ModRenderType.LINES);
+                renderTugRouteNodeBounds(pose, lineBuffer, camPos, node.toBlockPos(), routeRed, routeGreen, routeBlue, alpha);
+                RouteMarkerRenderer.renderLabelAtY(pose, buffer, camera, camPos,
+                        nodePos.x, nodePos.y + TUG_ROUTE_LABEL_Y_OFFSET, nodePos.z,
+                        node.getDisplayName(i), alpha);
             }
-            var lineBuffer = buffer.getBuffer(ModRenderType.LINES);
-            renderTugRouteNodeBounds(pose, lineBuffer, camPos, node.toBlockPos(), routeRed, routeGreen, routeBlue, alpha);
-            RouteMarkerRenderer.renderLabelAtY(pose, buffer, camera, camPos,
-                    nodePos.x, nodePos.y + TUG_ROUTE_LABEL_Y_OFFSET, nodePos.z,
-                    node.getDisplayName(i), alpha);
-        }
 
-        if (!renderedTugRouteTargetPreview) {
-            renderTargetedTugRouteWater(pose, buffer, camPos, route);
-            renderedTugRouteTargetPreview = true;
-        }
+            if (!renderedTugRouteTargetPreview) {
+                renderTargetedTugRouteWater(pose, buffer, camPos, route);
+                renderedTugRouteTargetPreview = true;
+            }
 
-        buffer.endBatch();
+            buffer.endBatch();
+        }
     }
 
     private static boolean isCompletionTarget(TugRoute route) {
@@ -1553,19 +1557,21 @@ public class ForgeClientEventHandler {
         }
         routes.sort(Comparator.comparingDouble(route -> positions.get(route.entityId()).pos().distanceToSqr(camPos)));
 
-        MultiBufferSource.BufferSource buffer = MultiBufferSource.immediate(new ByteBufferBuilder(16_384));
-        Map<CompositeStrokeKey, CompositeStroke> strokes = new HashMap<>();
-        for (TugRouteTrackerData route : routes) {
-            int colourValue = DyeColor.byId(route.dyeColorId()).getTextureDiffuseColor();
-            RouteColour colour = new RouteColour(
-                ((colourValue >> 16) & 0xFF) / 255.0F,
-                ((colourValue >> 8) & 0xFF) / 255.0F,
-                (colourValue & 0xFF) / 255.0F
-            );
-            addCompositeTugRoute(strokes, route, colour);
+        try (ByteBufferBuilder byteBufferBuilder = new ByteBufferBuilder(16_384)) {
+            MultiBufferSource.BufferSource buffer = MultiBufferSource.immediate(byteBufferBuilder);
+            Map<CompositeStrokeKey, CompositeStroke> strokes = new HashMap<>();
+            for (TugRouteTrackerData route : routes) {
+                int colourValue = DyeColor.byId(route.dyeColorId()).getTextureDiffuseColor();
+                RouteColour colour = new RouteColour(
+                    ((colourValue >> 16) & 0xFF) / 255.0F,
+                    ((colourValue >> 8) & 0xFF) / 255.0F,
+                    (colourValue & 0xFF) / 255.0F
+                );
+                addCompositeTugRoute(strokes, route, colour);
+            }
+            renderCompositeStrokes(event.getPoseStack(), buffer, camPos, strokes, MAX_TRACKED_TUG_ROUTE_VERTICES_PER_FRAME);
+            buffer.endBatch();
         }
-        renderCompositeStrokes(event.getPoseStack(), buffer, camPos, strokes, MAX_TRACKED_TUG_ROUTE_VERTICES_PER_FRAME);
-        buffer.endBatch();
     }
 
     private static boolean isTrackedRouteNearCamera(TugRouteTrackerData route, Vec3 camPos) {
@@ -1599,27 +1605,29 @@ public class ForgeClientEventHandler {
             || VehicleTrackerPacketHandler.locoRoutes.isEmpty()) {
             return;
         }
-        MultiBufferSource.BufferSource buffer = MultiBufferSource.immediate(new ByteBufferBuilder(16_384));
-        Map<CompositeStrokeKey, CompositeStroke> strokes = new HashMap<>();
-        List<LocoRouteTrackerData> routes = new ArrayList<>(VehicleTrackerPacketHandler.locoRoutes.values());
-        routes.sort(Comparator.comparingInt(LocoRouteTrackerData::entityId));
-        Level level = Minecraft.getInstance().level;
-        for (LocoRouteTrackerData route : routes) {
-            int colour = DyeColor.byId(route.dyeColorId()).getTextureDiffuseColor();
-            RouteColour routeColour = new RouteColour(
-                ((colour >> 16) & 0xFF) / 255.0F,
-                ((colour >> 8) & 0xFF) / 255.0F,
-                (colour & 0xFF) / 255.0F
-            );
-            addCompositeLocoRoute(strokes,
-                getTrackedLocoRenderPoints(level, route.pathVertices(), route.waypointPositions()),
-                route.entityId(), routeColour);
-            for (BlockPos waypoint : route.waypointPositions()) {
-                addLocoWaypointStrokes(strokes, level, waypoint, route.entityId(), routeColour);
+        try (ByteBufferBuilder byteBufferBuilder = new ByteBufferBuilder(16_384)) {
+            MultiBufferSource.BufferSource buffer = MultiBufferSource.immediate(byteBufferBuilder);
+            Map<CompositeStrokeKey, CompositeStroke> strokes = new HashMap<>();
+            List<LocoRouteTrackerData> routes = new ArrayList<>(VehicleTrackerPacketHandler.locoRoutes.values());
+            routes.sort(Comparator.comparingInt(LocoRouteTrackerData::entityId));
+            Level level = Minecraft.getInstance().level;
+            for (LocoRouteTrackerData route : routes) {
+                int colour = DyeColor.byId(route.dyeColorId()).getTextureDiffuseColor();
+                RouteColour routeColour = new RouteColour(
+                    ((colour >> 16) & 0xFF) / 255.0F,
+                    ((colour >> 8) & 0xFF) / 255.0F,
+                    (colour & 0xFF) / 255.0F
+                );
+                addCompositeLocoRoute(strokes,
+                    getTrackedLocoRenderPoints(level, route.pathVertices(), route.waypointPositions()),
+                    route.entityId(), routeColour);
+                for (BlockPos waypoint : route.waypointPositions()) {
+                    addLocoWaypointStrokes(strokes, level, waypoint, route.entityId(), routeColour);
+                }
             }
+            renderCompositeStrokes(event.getPoseStack(), buffer, camPos, strokes, Integer.MAX_VALUE);
+            buffer.endBatch();
         }
-        renderCompositeStrokes(event.getPoseStack(), buffer, camPos, strokes, Integer.MAX_VALUE);
-        buffer.endBatch();
     }
 
     @SubscribeEvent
@@ -1629,6 +1637,9 @@ public class ForgeClientEventHandler {
         }
 
         Player player = Minecraft.getInstance().player;
+        if (player == null) {
+            return;
+        }
 
         renderedTugRouteTargetPreview = false;
 
@@ -1646,67 +1657,69 @@ public class ForgeClientEventHandler {
             renderTrackedTugRoutes(event, player, camPos);
             renderTrackedLocoRoutes(event, camPos);
 
-            MultiBufferSource.BufferSource renderTypeBuffer = MultiBufferSource.immediate(new ByteBufferBuilder(1536));
+            try (ByteBufferBuilder byteBufferBuilder = new ByteBufferBuilder(1536)) {
+                MultiBufferSource.BufferSource renderTypeBuffer = MultiBufferSource.immediate(byteBufferBuilder);
 
-            for(EntityPosition position : VehicleTrackerPacketHandler.toRender){
-                @Nullable
-                Entity entity = player.level().getEntity(position.id());
+                for(EntityPosition position : VehicleTrackerPacketHandler.toRender){
+                    @Nullable
+                    Entity entity = player.level().getEntity(position.id());
 
-                Vec3 entityPos = entity != null ? entity.getPosition(event.getPartialTick().getGameTimeDeltaPartialTick(false)) : position.pos();
-                Vec3 iconRenderPos = computeFixedDistance(entityPos, camPos, 1.0);
-                Vec3 textRenderPos = computeFixedDistance(entityPos, camPos, 0.9);
-                PoseStack matrixStack = event.getPoseStack();
+                    Vec3 entityPos = entity != null ? entity.getPosition(event.getPartialTick().getGameTimeDeltaPartialTick(false)) : position.pos();
+                    Vec3 iconRenderPos = computeFixedDistance(entityPos, camPos, 1.0);
+                    Vec3 textRenderPos = computeFixedDistance(entityPos, camPos, 0.9);
+                    PoseStack matrixStack = event.getPoseStack();
 
-                matrixStack.pushPose();
-                {
-                    matrixStack.translate(iconRenderPos.x - camPos.x, iconRenderPos.y  - camPos.y, iconRenderPos.z - camPos.z);
-                    matrixStack.mulPose(Axis.YP.rotationDegrees(-camera.getYRot()));
-                    matrixStack.mulPose(Axis.XP.rotationDegrees(camera.getXRot()));
+                    matrixStack.pushPose();
+                    {
+                        matrixStack.translate(iconRenderPos.x - camPos.x, iconRenderPos.y  - camPos.y, iconRenderPos.z - camPos.z);
+                        matrixStack.mulPose(Axis.YP.rotationDegrees(-camera.getYRot()));
+                        matrixStack.mulPose(Axis.XP.rotationDegrees(camera.getXRot()));
 
-                    Minecraft.getInstance().getItemRenderer().renderStatic(
-                            new ItemStack(EntityItemMap.get(position.type())),
-                            ItemDisplayContext.GROUND,
-                            150,
-                            OverlayTexture.NO_OVERLAY,
-                            matrixStack,
-                            renderTypeBuffer,
-                            player.level(),
-                            position.id());
-                }
-                matrixStack.popPose();
-                matrixStack.pushPose();
-                {
-                    matrixStack.translate(textRenderPos.x - camPos.x, textRenderPos.y - camPos.y, textRenderPos.z - camPos.z);
-                    matrixStack.mulPose(Axis.YP.rotationDegrees(-camera.getYRot()));
-                    matrixStack.mulPose(Axis.XP.rotationDegrees(camera.getXRot()));
+                        Minecraft.getInstance().getItemRenderer().renderStatic(
+                                new ItemStack(EntityItemMap.get(position.type())),
+                                ItemDisplayContext.GROUND,
+                                150,
+                                OverlayTexture.NO_OVERLAY,
+                                matrixStack,
+                                renderTypeBuffer,
+                                player.level(),
+                                position.id());
+                    }
+                    matrixStack.popPose();
+                    matrixStack.pushPose();
+                    {
+                        matrixStack.translate(textRenderPos.x - camPos.x, textRenderPos.y - camPos.y, textRenderPos.z - camPos.z);
+                        matrixStack.mulPose(Axis.YP.rotationDegrees(-camera.getYRot()));
+                        matrixStack.mulPose(Axis.XP.rotationDegrees(camera.getXRot()));
 
-                    matrixStack.scale(-0.025F, -0.025F, -0.025F);
+                        matrixStack.scale(-0.025F, -0.025F, -0.025F);
 
-                    Font fontRenderer = Minecraft.getInstance().font;
-                    String text = String.format("%.1fm", position.pos().distanceTo(player.position()));
+                        Font fontRenderer = Minecraft.getInstance().font;
+                        String text = String.format("%.1fm", position.pos().distanceTo(player.position()));
 
-                    fontRenderer.drawInBatch(text,
-                            (-fontRenderer.width(text) / (float) 2), 0.0F,
-                            -1, true,
-                            matrixStack.last().pose(), renderTypeBuffer,
-                            Font.DisplayMode.NORMAL,
-                            0, 15728880);
-
-                    if (entity != null && entity.hasCustomName()) {
-                        var name = entity.getCustomName();
-                        matrixStack.translate(0, -20, 0);
-                        fontRenderer.drawInBatch(name,
-                                (-fontRenderer.width(name) / (float) 2), 0.0F,
+                        fontRenderer.drawInBatch(text,
+                                (-fontRenderer.width(text) / (float) 2), 0.0F,
                                 -1, true,
                                 matrixStack.last().pose(), renderTypeBuffer,
                                 Font.DisplayMode.NORMAL,
                                 0, 15728880);
-                    }
-                }
-                matrixStack.popPose();
-            }
 
-            renderTypeBuffer.endBatch();
+                        if (entity != null && entity.hasCustomName()) {
+                            var name = entity.getCustomName();
+                            matrixStack.translate(0, -20, 0);
+                            fontRenderer.drawInBatch(name,
+                                    (-fontRenderer.width(name) / (float) 2), 0.0F,
+                                    -1, true,
+                                    matrixStack.last().pose(), renderTypeBuffer,
+                                    Font.DisplayMode.NORMAL,
+                                    0, 15728880);
+                        }
+                    }
+                    matrixStack.popPose();
+                }
+
+                renderTypeBuffer.endBatch();
+            }
         }
     }
 

--- a/src/main/java/dev/murad/shipping/global/VehicleRegistrationData.java
+++ b/src/main/java/dev/murad/shipping/global/VehicleRegistrationData.java
@@ -50,6 +50,8 @@ public final class VehicleRegistrationData extends SavedData {
     private static final double TRACKING_DISTANCE_SQR = 160.0D * 160.0D;
     private static final int ROUTE_SNAPSHOT_INTERVAL = 10;
     private static final int MAX_TRACKED_VERTICES = 16_384;
+    // Mirrors MAX_TRACKED_TUGS / MAX_TRACKED_LOCOS enforced in the tracker packets' canonical constructors.
+    private static final int MAX_TRACKED_ROUTES = 1_000;
 
     private record RouteState(int entityId, int dyeColor, long revision, int distanceBucket) {}
 
@@ -228,6 +230,7 @@ public final class VehicleRegistrationData extends SavedData {
         int remaining = MAX_TRACKED_VERTICES;
         List<TugRouteTrackerData> routes = new ArrayList<>();
         for (AbstractTugEntity tug : tugs) {
+            if (routes.size() >= MAX_TRACKED_ROUTES) break;
             var route = TugRouteTrackerData.fromTug(tug);
             if (route.isPresent() && route.get().pathVertices().size() <= remaining) {
                 routes.add(route.get());
@@ -257,6 +260,7 @@ public final class VehicleRegistrationData extends SavedData {
         int remaining = MAX_TRACKED_VERTICES;
         List<LocoRouteTrackerData> routes = new ArrayList<>();
         for (AbstractLocomotiveEntity locomotive : locomotives) {
+            if (routes.size() >= MAX_TRACKED_ROUTES) break;
             var route = LocoRouteTrackerData.fromLocomotive(locomotive);
             if (route.isPresent() && route.get().pathVertices().size() <= remaining) {
                 routes.add(route.get());

--- a/src/main/java/dev/murad/shipping/network/client/LocoRouteTrackerData.java
+++ b/src/main/java/dev/murad/shipping/network/client/LocoRouteTrackerData.java
@@ -43,7 +43,7 @@ public record LocoRouteTrackerData(int entityId, int dyeColorId, List<BlockPos> 
             for (LocoRouteStep step : route.getSegments().get(segmentIndex).getSteps()) append(path, step.railPos());
             append(path, route.get((segmentIndex + 1) % route.size()).toBlockPos());
         }
-        if (path.size() < 2 || path.size() > MAX_PATH_VERTICES) return Optional.empty();
+        if (path.size() < 2 || path.size() > MAX_PATH_VERTICES || route.size() > MAX_WAYPOINTS) return Optional.empty();
         return Optional.of(new LocoRouteTrackerData(locomotive.getId(), locomotive.getColor(), path,
             route.stream().map(node -> node.toBlockPos().immutable()).toList()));
     }

--- a/src/main/java/dev/murad/shipping/util/LinkingHandler.java
+++ b/src/main/java/dev/murad/shipping/util/LinkingHandler.java
@@ -101,7 +101,7 @@ public class LinkingHandler<T extends Entity & LinkableEntity<T>> {
         if (leader.isPresent()) {
             writeNBT(leader.get(), compound);
         } else if (dominantNBT != null) {
-            compound.put(LinkableEntity.LinkSide.DOMINANT.name(), dominantNBT);
+            compound.put("dominant", dominantNBT);
         }
 
         compound.putBoolean("hasChild", follower.isPresent());

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,1 +1,0 @@
-public net.minecraft.world.level.block.entity.HopperBlockEntity tryMoveItems(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/entity/HopperBlockEntity;Ljava/util/function/BooleanSupplier;)Z


### PR DESCRIPTION
Prepares the 1.21.1 line for release: fixes the CI/publish pipeline for Java 21 + beta tags, then lands the confirmed release-readiness fixes from an adversarially-verified full-codebase review.

## CI & release plumbing (`bdc1d7d`)
- `setup-java`: Java 17 → **21** (project requires JDK 21), `adopt` → `temurin`
- `actions/checkout` + `actions/setup-java`: v2 → **v4**
- `publish-release.yml`: allow `-` in the extracted `mod_version` so `-beta.N`/`-rc.N` suffixes (e.g. `mc1.21.1-v1.21.1.0-beta.1`) are no longer truncated to the stable version

## Release-readiness fixes

Each fix is minimal and mirrors an existing sibling-class pattern already in the codebase.

### 🔴 Blockers — item duplication / loss on chunk unload
- **ChestBargeEntity** (`d002281`) — `remove()` dropped its full inventory on `UNLOADED_TO_CHUNK` while the handler was still serialized → dupe on reload. Added the `r != RemovalReason.UNLOADED_TO_CHUNK` guard used by `AbstractBargeEntity`/`AbstractTugEntity`.
- **ChestCarEntity** (`f0f1e6a`) — same bug on the rail side (also backs the Barrel Car). Same guard.

### 🟠 High
- **ChunkLoaderBargeEntity** (`955cac9`) — `add/readAdditionalSaveData` never chained to `super`, silently dropping color, spring-link and vanilla entity data on reload. Now chains to `super` first, matching `ChunkLoaderCarEntity`.
- **SteamLocomotiveEntity** (`ab3b98d`) / **EnergyLocomotiveEntity** (`d6394b7`) — fuel / capacitor item dropped on chunk unload (dupe). Same removal-reason guard.
- **ForgeClientEventHandler** (`ce614be`) — five per-frame `ByteBufferBuilder` allocations were never closed (native memory leak growing every render frame). Wrapped all five in try-with-resources; also added the missing null-`player` guard in `onRenderWorldLast`.

### 🟡 Medium
- **LinkingHandler** (`af47e1a`) — pending leader link was written under key `"DOMINANT"` but read as `"dominant"`, so the link was lost on re-save. Unified on `"dominant"`.
- **LocoRouteTrackerData** (`145ae63`) — `fromLocomotive` lacked the `MAX_WAYPOINTS` guard the record constructor enforces, throwing on the server tick for large routes. Added the guard (matches `TugRouteTrackerData`).

### ⚪ Low (cleanup / robustness)
- `59052c1` remove dead `HopperBlockEntity.tryMoveItems` access-transformer entry
- `0bb48d1` remove unused `TRAIN_SPEED` static (snapshotted server config at class-init)
- `8200549` remove dead no-op `setValue` in `VesselDetectorTileEntity`
- `bc4ed3a` remove duplicate identical `shouldRender` check in `AbstractVesselRenderer`
- `eb8f199` cap wrench route-tracker snapshots to the packet's route limit (avoids server-tick throw)
- `7bcca67` correct config comment defaults (`trainMaxSpeed`, `locoBaseSpeed`, `fishingTreasureChance`)

## Verification
- All changes verified by reading + structural checks (brace/paren balance on the large `ForgeClientEventHandler` reindent). **CI (`verify-pr`, now JDK 21) compiles + runs the JUnit suite on this PR.**
- ⚠️ Still needs a local `runClient` in-world smoke test (park a loaded vehicle, unload/reload the chunk, confirm no drop and intact contents) — CI can't do this.

## Deferred (follow-ups, intentionally not in this PR)
- `LocoRouteNode` double-write/int-read serialization asymmetry (changing the format risks existing saved route items — needs a compat-aware fix)
- License notice GPL-vs-LGPLv3 mismatch in `gradle.properties` (legal direction call)
- `publish-release.yml` missing `packages:write` permission for the GitHub Packages target
- Docking-station caps exposed only on the FACING face (vanilla hoppers can't pull — design decision)
